### PR TITLE
Tried to correct for missing buttons.py

### DIFF
--- a/wordclock_plugins/tetris/plugin.py
+++ b/wordclock_plugins/tetris/plugin.py
@@ -1,7 +1,7 @@
 # Authored by Markus E.
 
 import os
-import wordclock_tools.buttons as wcb
+import wordclock_tools.wordclock_interface as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 import time

--- a/wordclock_plugins/time_matrix/plugin.py
+++ b/wordclock_plugins/time_matrix/plugin.py
@@ -3,7 +3,7 @@
 import datetime
 import os
 import wordclock_plugins.time_default.time_dutch as time_dutch
-import wordclock_tools.buttons as wcb
+import wordclock_tools.wordclock_interface as wcb
 import wordclock_tools.wordclock_colors as wcc
 import random
 from ConfigParser import NoSectionError


### PR DESCRIPTION
File "/home/pi/rpi_wordclock/wordclock_plugins/time_matrix/plugin.py",
line 6, in <module>
import wordclock_tools.buttons as wcb
ImportError: No module named buttons